### PR TITLE
added buffer/seek indicator

### DIFF
--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -7,7 +7,7 @@ class AtomMusicView extends View
   currentTrack: null
   @content: ->
     @div class:'atom-music', =>
-      @div class:'audio-controls-container', =>
+      @div class:'audio-controls-container', outlet:'container', =>
         @div class:'btn-group btn-group-sm', =>
           @button class:'btn icon icon-playback-rewind', click:'prevTrack'
           @button class:'btn icon playback-button icon-playback-play', click:'togglePlayback'
@@ -19,6 +19,7 @@ class AtomMusicView extends View
         @div class:'inline-block playing-now-container', =>
           @span 'Now Playing : ', class:'highlight'
           @span 'Nothing to play', class:'highlight', outlet:'nowPlayingTitle'
+          @div id:'ticker',outlet:'ticker'
       @div class:'atom-music-list-container'
       @tag 'audio', class:'audio-player', outlet:'audio_player', =>
 
@@ -30,6 +31,12 @@ class AtomMusicView extends View
     @audio_player.on 'pause', ( ) =>
       $('.playback-button').removeClass('icon-playback-pause').addClass('icon-playback-play')
     @audio_player.on 'ended', @songEnded
+    @container.on 'click', ( evt ) =>
+      if 35 <= evt.offsetY <= 40 and @currentTrack?
+        @ticker.context.style.width = evt.offsetX+"px"
+        totalTime = @audio_player[0].duration
+        factor = totalTime / @container.width()
+        @audio_player[0].currentTime = evt.offsetX * factor
 
   show: ->
     @panel ?= atom.workspace.addBottomPanel(item:this)
@@ -42,12 +49,19 @@ class AtomMusicView extends View
       @show()
       @pulsing()
 
+  moveTicker: ->
+    if @currentTrack?
+      timeSpent = @audio_player[0].currentTime
+      totalTime = @audio_player[0].duration
+      percentCompleted = timeSpent / totalTime
+      @ticker.context.style.width = percentCompleted * @container.width() + 'px'
+
   pulsing: ->
-    self = @
-    setInterval ( ) ->
-      $(self).addClass('pulse')
-      setTimeout ( ) ->
-        $(self).removeClass('pulse')
+    setInterval ( ) =>
+      $(@).addClass('pulse')
+      @moveTicker()
+      setTimeout ( ) =>
+        $(@).removeClass('pulse')
       , 2000
     , 4000
 

--- a/styles/atom-music.less
+++ b/styles/atom-music.less
@@ -37,3 +37,12 @@
     display: none;
   }
 }
+
+#ticker {
+  width: 0px;
+  height: 2px;
+  background-color: black;
+  position: absolute;
+  top: 98%;
+  left: 0px;
+}


### PR DESCRIPTION
This shows how far into the song you are and gives you the ability to seek through it. You'll only see the indicator when the pulse blueness is on. From the very bottom of atom-music with a 5 pixel threshold going up is where you click to seek. This is generally the sweetspot:

![atom-music-snap2](https://cloud.githubusercontent.com/assets/1617698/11888957/4a58ec5a-a4f8-11e5-8ea4-603400d93540.png)

edit: last picture I put didn't show the ticker
