### PR TITLE
Add commands 

### DIFF
--- a/lib/atom-music-playlist-view.coffee
+++ b/lib/atom-music-playlist-view.coffee
@@ -1,21 +1,19 @@
-{View,SelectListView} = require 'atom-space-pen-views'
-$ = require 'jquery'
+{View, SelectListView} = require 'atom-space-pen-views'
 
 class PlayListView extends SelectListView
   initialize: (@player, @items) ->
-    super
-    @addClass 'overlay from-top'
+    super()
     @setItems @items
     @panel ?= atom.workspace.addModalPanel item:@
     @panel.show()
     @focusFilterEditor()
 
   viewForItem: (track)->
-      "<li><!--<img src=''width='20' height='20' >-->&nbsp; &nbsp; #{track.name}</li>"
+    "<li>&nbsp; &nbsp; #{track.name}</li>"
 
   confirmed: (track)->
-      @player.playTrackByItem(track)
-      @parent().remove()
+    @player.playTrackByItem(track)
+    @parent().remove()
 
   cancelled: ->
     @parent().remove()

--- a/lib/atom-music-playlist-view.coffee
+++ b/lib/atom-music-playlist-view.coffee
@@ -4,19 +4,22 @@ class PlayListView extends SelectListView
   initialize: (@player, @items) ->
     super()
     @setItems @items
-    @panel ?= atom.workspace.addModalPanel item:@
+    @panel ?= atom.workspace.addModalPanel item: @, autoFocus: true
     @panel.show()
     @focusFilterEditor()
 
-  viewForItem: (track)->
-    "<li>&nbsp; &nbsp; #{track.name}</li>"
+  destroy: ->
+    @panel?.destroy()
 
-  confirmed: (track)->
-    @player.playTrackByItem(track)
-    @parent().remove()
+  viewForItem: (track) ->
+    "<li>#{track.name}</li>"
+
+  confirmed: (track) ->
+    @player.playTrack(track)
+    @panel.destroy()
 
   cancelled: ->
-    @parent().remove()
+    @panel.destroy()
 
   getFilterKey: ->
     "name"

--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -19,7 +19,7 @@ class AtomMusicView extends View
       @shuffle = false
 
   @content: ->
-    @div class:'atom-music', =>
+    @div class:'atom-music pulse', =>
       @div class:'audio-controls-container', outlet:'container', =>
         @div class:'btn-group btn-group-sm', =>
           @button class:'btn icon icon-jump-left', click:'back15'
@@ -45,14 +45,13 @@ class AtomMusicView extends View
           @span 'Nothing to play', class:'highlight', outlet:'nowPlayingTitle'
           @div id:'ticker',outlet:'ticker'
       @div class:'atom-music-list-container'
-      @tag 'audio', class:'audio-player', outlet:'audio_player', =>
+      @tag 'audio', class:'audio-player', outlet:'audio_player', ->
 
   initialize: ->
-    self = @
     @musicFileSelectionInput.on 'change', @filesBrowsed
-    @audio_player.on 'play', ( ) =>
+    @audio_player.on 'play', ( ) ->
       $('.playback-button').removeClass('icon-playback-play').addClass('icon-playback-pause')
-    @audio_player.on 'pause', ( ) =>
+    @audio_player.on 'pause', ( ) ->
       $('.playback-button').removeClass('icon-playback-pause').addClass('icon-playback-play')
     @audio_player.on 'ended', @songEnded
     @container.on 'click', ( evt ) =>
@@ -66,12 +65,17 @@ class AtomMusicView extends View
     @panel ?= atom.workspace.addBottomPanel(item:this)
     @panel.show()
 
+
   toggle:->
     if @panel?.isVisible()
       @hide()
+      clearInterval(@tickerInterval)
     else
       @show()
-      @pulsing()
+      @tickerInterval = setInterval () =>
+        @moveTicker()
+      , 100
+
 
   moveTicker: ->
     if @currentTrack?
@@ -80,17 +84,7 @@ class AtomMusicView extends View
       percentCompleted = timeSpent / totalTime
       @ticker.context.style.width = percentCompleted * @container.width() + 'px'
 
-  pulsing: ->
-    setInterval ( ) =>
-      $(@).addClass('pulse')
-      @moveTicker()
-      setTimeout ( ) =>
-        $(@).removeClass('pulse')
-      , 2000
-    , 4000
-
   songEnded: ( e ) =>
-    console.log "Changing track"
     @nextTrack()
 
   skip: ( seconds )->

--- a/lib/atom-music.coffee
+++ b/lib/atom-music.coffee
@@ -4,15 +4,23 @@ AtomMusicView = require './atom-music-view'
 module.exports = AtomMusic =
   atomMusicView: null
   modalPanel: null
-  subscriptions: null
+  subscriptions: new CompositeDisposable
 
   activate: (state) ->
     @atomMusicView = new AtomMusicView(state.atomMusicViewState)
-    # Register command that toggles this view
-    atom.commands.add 'atom-workspace', 'atom-music:toggle': => @atomMusicView.toggle()
+
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:toggle': => @atomMusicView.toggle()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:play-pause': => @atomMusicView.togglePlayback()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:toggle-shuffle': => @atomMusicView.toggleShuffle()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:show-playlist': => @atomMusicView.showPlayList()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:forward-15s': => @atomMusicView.forward15()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:backward-15s': => @atomMusicView.back15()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:next-track': => @atomMusicView.nextTrack()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:previous-track': => @atomMusicView.prevTrack()
 
   deactivate: ->
-    @atomMusicView.destroy()
+    @atomMusicView?.destroy()
+    @subscriptions?.dispose()
 
   serialize: ->
     atomMusicViewState: @atomMusicView.serialize()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.1.0",
-    "jquery": "^2.1.4"
+    "atom-space-pen-views": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
     "audio"
   ],
   "activationCommands": {
-    "atom-workspace": "atom-music:toggle"
+    "atom-workspace": [
+      "atom-music:toggle",
+      "atom-music:play-pause",
+      "atom-music:toggle-shuffle",
+      "atom-music:show-playlist",
+      "atom-music:forward-15s",
+      "atom-music:backward-15s",
+      "atom-music:next-track",
+      "atom-music:previous-track"
+    ]
   },
   "repository": "https://github.com/sdinesh86/atom-music",
   "license": "MIT",

--- a/spec/atom-music-spec.coffee
+++ b/spec/atom-music-spec.coffee
@@ -31,7 +31,7 @@ describe "AtomMusic", ->
         atomMusicElement = workspaceElement.querySelector('.atom-music')
         expect(atomMusicElement).toExist()
 
-        atomMusicPanel = atom.workspace.panelForItem(atomMusicElement)
+        atomMusicPanel = atom.workspace.panelForItem(AtomMusic.atomMusicView)
         expect(atomMusicPanel.isVisible()).toBe true
         atom.commands.dispatch workspaceElement, 'atom-music:toggle'
         expect(atomMusicPanel.isVisible()).toBe false

--- a/styles/atom-music.less
+++ b/styles/atom-music.less
@@ -7,10 +7,9 @@
 .atom-music {
   height: auto;
   border: 1px solid #000;
-  transition: border 2s linear;
 
   &.pulse {
-    border-color: #02E9FF;
+    animation: pulse 2s linear infinite alternate;
   }
 
   .audio-controls-container {
@@ -45,4 +44,14 @@
   position: absolute;
   top: 98%;
   left: 0px;
+}
+
+@keyframes pulse {
+  from {
+    border-color: #000;
+  }
+
+  to {
+    border-color: #02E9FF;
+  }
 }

--- a/styles/atom-music.less
+++ b/styles/atom-music.less
@@ -6,7 +6,7 @@
 
 .atom-music {
   height: auto;
-  border: 1px solid #000;
+  border: 1px solid #02E9FF;
 
   &.pulse {
     animation: pulse 2s linear infinite alternate;
@@ -48,10 +48,10 @@
 
 @keyframes pulse {
   from {
-    border-color: #000;
+    border-color: #02E9FF;
   }
 
   to {
-    border-color: #02E9FF;
+    border-color: #000;
   }
 }


### PR DESCRIPTION
I updated it a little bit, fixed serialization, changed the pulsing to a css animation, and added the following commands to the command palette:

command | description
--------|------------
atom-music:play-pause | Toggle play/pause
atom-music:toggle-shuffle | Toggle shuffle
atom-music:show-playlist | Show playlist
atom-music:forward-15s | Skip forward 15 seconds
atom-music:backward-15s | Skip Backward 15 seconds
atom-music:next-track | Play next track
atom-music:previous-track | Play previous track


