### PR TITLE
Multi window support

### DIFF
--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -10,6 +10,8 @@ class AtomMusicView extends View
 
   constructor: (serializedState) ->
     super()
+    @windowId = atom.getCurrentWindow().id
+    @fromWindowChange = false
     if serializedState?
       @isPlaying = serializedState.isPlaying
       @playList = serializedState.playList or []
@@ -62,11 +64,17 @@ class AtomMusicView extends View
     @musicFileSelectionInput.on 'change', @filesBrowsed
     @audio_player.on 'play', () =>
       @isPlaying = true
+      atom.config.set 'atom-music.state.playerWindowId', @windowId
+      atom.config.set "atom-music.state.playing", true
       @playbackButton.removeClass('icon-playback-play').addClass('icon-playback-pause')
       @container.addClass('pulse')
       @startTicker()
     @audio_player.on 'pause', () =>
       @isPlaying = false
+      if @fromWindowChange
+        @fromWindowChange = false
+      else
+        atom.config.set "atom-music.state.playing", false
       @playbackButton.removeClass('icon-playback-pause').addClass('icon-playback-play')
       @container.removeClass('pulse')
       @stopTicker()

--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -2,16 +2,17 @@
 playListView = require './atom-music-playlist-view'
 module.exports =
 class AtomMusicView extends View
-  isPlaying = false
-  playList = []
-  playListCopy = []
-  currentTrack = null
-  shuffle = false
 
   constructor: (serializedState) ->
     super()
-    @windowId = atom.getCurrentWindow().id
+    @isPlaying = false
+    @playList = []
+    @playListCopy = []
+    @currentTrack = null
+    @shuffle = false
     @fromWindowChange = false
+    @windowId = atom.getCurrentWindow().id
+
     if serializedState?
       @isPlaying = serializedState.isPlaying
       @playList = serializedState.playList or []

--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -11,7 +11,7 @@ class AtomMusicView extends View
     @currentTrack = null
     @shuffle = false
     @fromWindowChange = false
-    @windowId = atom.getCurrentWindow().id
+    @windowId = process.pid
 
     if serializedState?
       @isPlaying = serializedState.isPlaying

--- a/lib/atom-music-view.coffee
+++ b/lib/atom-music-view.coffee
@@ -248,7 +248,7 @@ class AtomMusicView extends View
     @container.removeClass('pulse')
 
   serialize: ->
-    isPlaying: @isPlaying
+    isPlaying: false # @isPlaying
     playList: @playList
     playListCopy: @playListCopy
     currentTrack: @currentTrack

--- a/lib/atom-music.coffee
+++ b/lib/atom-music.coffee
@@ -6,6 +6,25 @@ module.exports = AtomMusic =
   modalPanel: null
   subscriptions: new CompositeDisposable
 
+  config:
+    state:
+      title: 'Multi-Window State'
+      type: 'object'
+      collapsed: true
+      order: -1
+      description: 'Changing these values manually may prevent atom-music from working properly.'
+      properties:
+        playing:
+          title: 'Playing'
+          type: 'boolean'
+          order: 1
+          default: false
+        playerWindowId:
+          title: 'Window ID'
+          type: 'integer'
+          order: 2
+          default: 0
+
   activate: (state) ->
     @atomMusicView = new AtomMusicView(state.atomMusicViewState)
     @subscriptions.add atom.workspace.addOpener (uri) =>
@@ -19,6 +38,17 @@ module.exports = AtomMusic =
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:backward-15s': => @atomMusicView.back15()
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:next-track': => @atomMusicView.nextTrack()
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-music:previous-track': => @atomMusicView.prevTrack()
+
+    @subscriptions.add atom.config.onDidChange 'atom-music.state.playing', (playing) =>
+      windowId = atom.config.get 'atom-music.state.playerWindowId'
+      console.log "p", windowId, @atomMusicView.windowId, playing.newValue, @atomMusicView.isPlaying
+      if windowId is @atomMusicView.windowId
+        @atomMusicView.togglePlayback() if playing.newValue isnt @atomMusicView.isPlaying
+    @subscriptions.add atom.config.onDidChange 'atom-music.state.playerWindowId', (windowId) =>
+      console.log "w", windowId.newValue, @atomMusicView.windowId, @atomMusicView.isPlaying
+      if windowId.newValue isnt @atomMusicView.windowId
+        @atomMusicView.fromWindowChange = true
+        @atomMusicView.togglePlayback() if @atomMusicView.isPlaying
 
   deactivate: ->
     @atomMusicView?.destroy()

--- a/lib/atom-music.coffee
+++ b/lib/atom-music.coffee
@@ -41,11 +41,9 @@ module.exports = AtomMusic =
 
     @subscriptions.add atom.config.onDidChange 'atom-music.state.playing', (playing) =>
       windowId = atom.config.get 'atom-music.state.playerWindowId'
-      console.log "p", windowId, @atomMusicView.windowId, playing.newValue, @atomMusicView.isPlaying
       if windowId is @atomMusicView.windowId
         @atomMusicView.togglePlayback() if playing.newValue isnt @atomMusicView.isPlaying
     @subscriptions.add atom.config.onDidChange 'atom-music.state.playerWindowId', (windowId) =>
-      console.log "w", windowId.newValue, @atomMusicView.windowId, @atomMusicView.isPlaying
       if windowId.newValue isnt @atomMusicView.windowId
         @atomMusicView.fromWindowChange = true
         @atomMusicView.togglePlayback() if @atomMusicView.isPlaying

--- a/lib/atom-music.coffee
+++ b/lib/atom-music.coffee
@@ -41,7 +41,7 @@ module.exports = AtomMusic =
 
     @subscriptions.add atom.config.onDidChange 'atom-music.state.playing', (playing) =>
       windowId = atom.config.get 'atom-music.state.playerWindowId'
-      if windowId is @atomMusicView.windowId
+      if windowId is @atomMusicView.windowId or windowId is 0
         @atomMusicView.togglePlayback() if playing.newValue isnt @atomMusicView.isPlaying
     @subscriptions.add atom.config.onDidChange 'atom-music.state.playerWindowId', (windowId) =>
       if windowId.newValue isnt @atomMusicView.windowId
@@ -49,6 +49,10 @@ module.exports = AtomMusic =
         @atomMusicView.togglePlayback() if @atomMusicView.isPlaying
 
   deactivate: ->
+    windowId = atom.config.get 'atom-music.state.playerWindowId'
+    if windowId is @atomMusicView.windowId
+      atom.config.set 'atom-music.state.playerWindowId', 0
+      atom.config.set 'atom-music.state.playing', false
     @atomMusicView?.destroy()
     @subscriptions?.dispose()
 


### PR DESCRIPTION
Allow play and pause from multiple windows.

This PR uses config variables to tell when it is playing and which window holds the `audio` tag.